### PR TITLE
Experimenting with passing matrix outputs from previous matrix jobs

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -110,11 +110,11 @@ jobs:
           matrix-step-name: ${{ github.job }}
           matrix-key: ${{ matrix.image_name }}
           outputs: |-
-            host_namespace: ${{ matrix.host_namespace }}
-            image: ${{ matrix.image_name }}
-            context: ${{ matrix.context }}
-            tags: ${{ steps.meta.outputs.tags }}
-            labels: ${{ steps.meta.outputs.labels }}
+            host_namespace: "${{ matrix.host_namespace }}"
+            image: "${{ matrix.image_name }}"
+            context: "${{ matrix.context }}"
+            tags: "${{ steps.meta.outputs.tags }}"
+            labels: "${{ steps.meta.outputs.labels }}"
 
 
   ## Read matrix outputs 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -134,7 +134,9 @@ jobs:
       - name: Print matrix read values
         run: |
           echo "Matrix values result: ${{ steps.matrix-read.outputs.result }}"
-          echo "FromJSON Matrix values result: ${{ fromJson(steps.matrix-read.outputs.result) }}"
+          echo "FromJSON Matrix values result: ${{ fromJson(steps.matrix-read.outputs.result).image }}"
+          echo "Matrix values image: ${{ steps.matrix-read.outputs.result.image }}"
+          echo "FromJSON Matrix values image: ${{ fromJson(steps.matrix-read.outputs.result).image }}"
 
     outputs:
       result: "${{ steps.matrix-read.outputs.result }}"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -113,7 +113,8 @@ jobs:
             host_namespace: ${{ matrix.host_namespace }}
             image: ${{ matrix.image_name }}
             context: ${{ matrix.context }}
-            tags_labels: ${{ fromJSON(steps.meta.outputs.json) }}
+            tags_labels: ${{ steps.meta.outputs.json }}
+          # tags_labels: ${{ fromJSON(steps.meta.outputs.json) }}
 
       - name: Print meta JSON
         run: |

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -145,7 +145,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MATRIX_PARAMETERS: ${{ fromJson(needs.read-matrix-build-parameters.outputs.result) }}
+    #   MATRIX_PARAMETERS: ${{ fromJson(needs.read-matrix-build-parameters.outputs.result) }}
+      MATRIX_PARAMETERS: ${{ needs.read-matrix-build-parameters.outputs.result }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -113,10 +113,7 @@ jobs:
             host_namespace: ${{ matrix.host_namespace }}
             image: ${{ matrix.image_name }}
             context: ${{ matrix.context }}
-            tags: |
-              ${{ steps.meta.outputs.tags }}
-            labels: |
-              ${{ steps.meta.outputs.labels }}
+            tags_labels: ${{ fromJSON(steps.meta.outputs.json) }}
 
 
   ## Read matrix outputs 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -103,9 +103,40 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image_name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image_name }}
 
-  run-demo-automated-test:
-    needs: docker-build-and-push-images
+      - name: Write Matrix Build Parameters to Output
+        uses: cloudposse/github-action-matrix-outputs-write@v1
+        id: matrix-write
+        with:
+          matrix-step-name: ${{ github.job }}
+          matrix-key: ${{ matrix.image_name }}
+          outputs: |-
+            host_namespace: ${{ matrix.host_namespace }}
+            image: ${{ matrix.image_name }}
+            context: ${{ matrix.context }}
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+
+
+  ## Read matrix outputs 
+  read-matrix-build-parameters:
     runs-on: ubuntu-latest
+    needs: [docker-build-and-push-images]
+    steps:
+      - uses: cloudposse/github-action-matrix-outputs-read@v1
+        id: matrix-read
+        with:
+          matrix-step-name: docker-build-and-push-images
+
+    outputs:
+      result: "${{ steps.matrix-read.outputs.result }}"
+
+
+  run-demo-automated-test:
+    needs: [docker-build-and-push-images, read-matrix-build-parameters]
+    runs-on: ubuntu-latest
+
+    env:
+      MATRIX_PARAMETERS: ${{ fromJson(needs.read-matrix-build-parameters.outputs.result) }}
 
     steps:
       - name: Checkout
@@ -113,8 +144,14 @@ jobs:
         with:
           fetch-depth: 0
 
+
+      - name: Print Matrix Build Parameters
+        run: |
+          echo "Entire matrix parameters: ${{ env.MATRIX_PARAMETERS }}"
+
       - name: List Docker images
         run: docker images
 
       - name: Run automated test script
+        timeout-minutes: 30
         run: bash demo-automated-testing.sh 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -163,6 +163,9 @@ jobs:
       - name: Print Matrix Build Parameters
         run: |
           echo "Entire matrix parameters: ${{ env.MATRIX_PARAMETERS }}"
+          echo "Matrix image: ${{ env.MATRIX_PARAMETERS.image }}"
+          echo "mqtt-server image: ${{ env.MATRIX_PARAMETERS.image.mqtt-server }}"
+          echo "nodered image: ${{ env.MATRIX_PARAMETERS.image.nodered }}"
 
       - name: Build and push mqtt-server
         uses: docker/build-push-action@v5

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - host_namespace: ghcr.io/everest/everest-demo
-            image_name: manager
-            context: ./manager
+          # - host_namespace: ghcr.io/everest/everest-demo
+          #   image_name: manager
+          #   context: ./manager
           - host_namespace: ghcr.io/everest/everest-demo
             image_name: mqtt-server
             context: ./mosquitto
@@ -125,6 +125,10 @@ jobs:
         id: matrix-read
         with:
           matrix-step-name: docker-build-and-push-images
+
+      - name: Print matrix read values
+        run: |
+          echo "Matrix values result: ${{ steps.matrix-read.outputs.result }}"
 
     outputs:
       result: "${{ steps.matrix-read.outputs.result }}"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -109,12 +109,14 @@ jobs:
         with:
           matrix-step-name: ${{ github.job }}
           matrix-key: ${{ matrix.image_name }}
-          outputs: |-
-            host_namespace: "${{ matrix.host_namespace }}"
-            image: "${{ matrix.image_name }}"
-            context: "${{ matrix.context }}"
-            tags: "${{ steps.meta.outputs.tags }}"
-            labels: "${{ steps.meta.outputs.labels }}"
+          outputs: |
+            host_namespace: ${{ matrix.host_namespace }}
+            image: ${{ matrix.image_name }}
+            context: ${{ matrix.context }}
+            tags: >-
+              ${{ steps.meta.outputs.tags }}
+            labels: >-
+              ${{ steps.meta.outputs.labels }}
 
 
   ## Read matrix outputs 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -134,6 +134,7 @@ jobs:
       - name: Print matrix read values
         run: |
           echo "Matrix values result: ${{ steps.matrix-read.outputs.result }}"
+          echo "FromJSON Matrix values result: ${{ fromJson(steps.matrix-read.outputs.result) }}"
 
     outputs:
       result: "${{ steps.matrix-read.outputs.result }}"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -118,6 +118,8 @@ jobs:
       - name: Print meta JSON
         run: |
           echo "meta step JSON output values: ${{ fromJSON(steps.meta.outputs.json) }}"
+          echo "meta step JSON tags values: ${{ fromJSON(steps.meta.outputs.json).tags }}"
+          echo "meta step JSON labels values: ${{ fromJSON(steps.meta.outputs.json).labels }}"
 
   ## Read matrix outputs 
   read-matrix-build-parameters:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -144,8 +144,9 @@ jobs:
     needs: [docker-build-and-push-images, read-matrix-build-parameters]
     runs-on: ubuntu-latest
 
-    env:
-      MATRIX_PARAMETERS: ${{ fromJson(needs.read-matrix-build-parameters.outputs.result) }}
+    # env:
+    #   MATRIX_PARAMETERS: ${{ fromJson(needs.read-matrix-build-parameters.outputs.result) }}
+      MATRIX_PARAMETERS: ${{ needs.read-matrix-build-parameters.outputs.result }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -103,6 +103,9 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image_name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image_name }}
 
+      - name: List Docker images
+        run: docker images
+
       - name: Write Matrix Build Parameters to Output
         uses: cloudposse/github-action-matrix-outputs-write@v1
         id: matrix-write
@@ -157,10 +160,29 @@ jobs:
         with:
           fetch-depth: 0
 
-
       - name: Print Matrix Build Parameters
         run: |
           echo "Entire matrix parameters: ${{ env.MATRIX_PARAMETERS }}"
+
+      - name: Build and push mqtt-server
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ env.MATRIX_PARAMETERS.context.mqtt-server }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ env.MATRIX_PARAMETERS.tags_labels.mqtt-server.tags }}
+          labels: ${{ env.MATRIX_PARAMETERS.tags_labels.mqtt-server.labels }}
+          cache-from: type=gha,scope=${{ env.MATRIX_PARAMETERS.image.mqtt-server }}
+          cache-to: type=gha,mode=max,scope=${{ env.MATRIX_PARAMETERS.image.mqtt-server }}
+
+      - name: Build and push nodered
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ env.MATRIX_PARAMETERS.context.nodered }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ env.MATRIX_PARAMETERS.tags_labels.nodered.tags }}
+          labels: ${{ env.MATRIX_PARAMETERS.tags_labels.nodered.labels }}
+          cache-from: type=gha,scope=${{ env.MATRIX_PARAMETERS.image.nodered }}
+          cache-to: type=gha,mode=max,scope=${{ env.MATRIX_PARAMETERS.image.nodered }}
 
       - name: List Docker images
         run: docker images

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -113,9 +113,9 @@ jobs:
             host_namespace: ${{ matrix.host_namespace }}
             image: ${{ matrix.image_name }}
             context: ${{ matrix.context }}
-            tags: >-
+            tags: |
               ${{ steps.meta.outputs.tags }}
-            labels: >-
+            labels: |
               ${{ steps.meta.outputs.labels }}
 
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -115,6 +115,9 @@ jobs:
             context: ${{ matrix.context }}
             tags_labels: ${{ fromJSON(steps.meta.outputs.json) }}
 
+      - name: Print meta JSON
+        run: |
+          echo "meta step JSON output values: ${{ fromJSON(steps.meta.outputs.json) }}"
 
   ## Read matrix outputs 
   read-matrix-build-parameters:


### PR DESCRIPTION
I need a way to reuse the tags, image names, contexts which are parameters used for building the image. Currently these are available in the matrix jobs but I need to access these in the subsequent jobs so that I can rebuild images from cache.

Using custom github action for this:
[Write outputs](https://github.com/cloudposse/github-action-matrix-outputs-write )
[Read outputs](https://github.com/cloudposse/github-action-matrix-outputs-read) 